### PR TITLE
feat: to ESM

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,6 @@ function middleware (options) {
   const mediaTypes = (options.alternativeMediaTypes || []).concat(['html'])
 
   return (req, res, next) => {
-
     const accept = accepts(req)
     if (accept.type(mediaTypes) !== 'html') {
       return next()
@@ -58,7 +57,6 @@ function middleware (options) {
       const graphBuffer = new streamBuffers.WritableStreamBuffer()
 
       graphBuffer.on('finish', () => {
-
         // restore original request headers for other hijack middlewares
         req.headers = reqHeaders
 
@@ -115,7 +113,7 @@ async function createRenderer (trifid) {
   const { config, server } = trifid
 
   // Load ES6 based templates
-  if (server){
+  if (server) {
     server.engine('html', cottonCandy({
       plugins: [
         cottonCandyInclude,

--- a/package.json
+++ b/package.json
@@ -19,13 +19,14 @@
     "accepts": "^1.3.8",
     "hijackresponse": "^4.0.1",
     "lodash": "^4.17.21",
-    "stream-buffers": "^3.0.2"
+    "stream-buffers": "^3.0.2",
+    "cotton-candy": "^1.1.0"
   },
   "devDependencies": {
     "express": "^4.18.1",
     "mocha": "^10.0.0",
     "standard": "^17.0.0",
     "supertest": "^6.2.4",
-    "trifid-core": "^2.0.0-alpha.4"
+    "trifid-core": "^2.0.0-alpha.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "trifid-plugin-renderer",
   "description": "Trifid graph HTML render plugin",
+  "type": "module",
   "version": "1.2.0",
   "license": "MIT",
   "homepage": "https://github.com/zazuko/trifid-plugin-renderer",
@@ -21,10 +22,10 @@
     "stream-buffers": "^3.0.2"
   },
   "devDependencies": {
-    "express": "^4.17.3",
-    "mocha": "^9.2.2",
-    "standard": "^16.0.4",
-    "supertest": "^6.2.2",
-    "trifid-core": "^1.3.0"
+    "express": "^4.18.1",
+    "mocha": "^10.0.0",
+    "standard": "^17.0.0",
+    "supertest": "^6.2.4",
+    "trifid-core": "^2.0.0-alpha.4"
   }
 }

--- a/test/support/dummy-renderer.js
+++ b/test/support/dummy-renderer.js
@@ -12,4 +12,4 @@ class DummyRenderer {
   }
 }
 
-module.exports = DummyRenderer
+export default DummyRenderer


### PR DESCRIPTION
Updated to ESM and new Config. 

I had trouble accessing trifid-core-loader, so

```js
const loader = async (modulePath) => {
  const middleware = await import(resolvePath(modulePath))
  return middleware.default
}
```

is duplicated in the meantime.